### PR TITLE
Update json version

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0 (11/8/2022)
+* Minimum json version bumped to 2.6.2
+
 ## 2.0.0 (6/14/2017)
 
 * Adds support for Woff2 ([#313](https://github.com/FontCustom/fontcustom/pull/313))

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,0 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-
-RSpec::Core::RakeTask.new "spec" do |s|
-  s.rspec_opts = "--color --format documentation"
-end
-
-task :default => :spec

--- a/fontcustom.gemspec
+++ b/fontcustom.gemspec
@@ -18,11 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "json", "~>1.4"
+  gem.add_dependency "json", "~>2.6.2"
   gem.add_dependency "thor", "~>0.14"
   gem.add_dependency "listen", ">=1.0","<4.0"
 
-  gem.add_development_dependency "rake", "~> 10"
-  gem.add_development_dependency "bundler"
   gem.add_development_dependency "rspec", "~>3.1.0"
 end

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -77,8 +77,8 @@ def createGlyph( name, source, code ):
             aligned_to_pixel_grid = (width % design_px == 0)
             if (aligned_to_pixel_grid):
                 shift = glyph.left_side_bearing % design_px
-                glyph.left_side_bearing = glyph.left_side_bearing - shift
-                glyph.right_side_bearing = glyph.right_side_bearing + shift
+                glyph.left_side_bearing = int(glyph.left_side_bearing) - int(shift)
+                glyph.right_side_bearing = int(glyph.right_side_bearing) + int(shift)
 
 # Add valid space glyph to avoid "unknown character" box on IE11
 glyph = font.createChar(32)

--- a/lib/fontcustom/version.rb
+++ b/lib/fontcustom/version.rb
@@ -1,3 +1,3 @@
 module Fontcustom
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Went with the latest version of the gem. All specs except one passed locally, but this spec also did not pass before updating and looks like it isn't `json` related?

```
1) Fontcustom::Watcher#watch should call generators when vectors change
     Failure/Error: Unable to find matching line from backtrace
       Exactly one instance should have received the following message(s) but didn't:
```

Tested by:
- Creating a branch in `unified-ui-assets` using this branch
- Running `bundle exec fontcustom compile`, patching a line fontcustom's python script that was failing
- Ran styleguide, which the readme says compile should affect, and it still worked
- Creating a branch in `nds` using the `unified-ui-assests` branch
- Testing the styleguide and component library in nds 