### PR TITLE
IT-1343: Update default to python3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0 (02/8/2023)
+* Add check for call status to eotlite.py
+* Update python default call to eotlitetool.py to python3
+
 ## 2.1.0 (11/8/2022)
 * Minimum json version bumped to 2.6.2
 

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -126,7 +126,8 @@ try:
     manifest['fonts'].append(fontfile + '.woff')
 
     # Convert EOT for IE7
-    subprocess.call('python ' + scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -o ' + fontfile + '.eot', shell=True)
+    subprocess.run('python3 ' + scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -o ' + fontfile + '.eot', shell=True, check=True)
+
     # check if windows
     if os.name == 'nt':
         subprocess.call('move ' + fontfile + '.eotlite ' + fontfile + '.eot', shell=True)

--- a/lib/fontcustom/version.rb
+++ b/lib/fontcustom/version.rb
@@ -1,3 +1,3 @@
 module Fontcustom
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
I don't have `python` in my path as I no longer have python2 installed. However I do have python3 ~~which I believe is installed by mac by default as well.~~ Edit: JK can't find anything online confirming which even is default (if any)

Tested against my local setup before these changes, ` bundle exec fontcustom compile` would return:
```
      status  Forcing compile.
       error  `fontforge` compilation failed. Try again with --debug for more details.
```
This produced no eot file due to the failure

After changes :
``` 
       debug  Copyright (c) 2000-2023. See AUTHORS for Contributors.
               License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
               with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.
               Version: 20230101
               Based on sources from 2023-01-01 05:27 UTC-D.
              /bin/sh: python: command not found
              Traceback (most recent call last):
                File "/Users/dburgess/.gem/ruby/2.7.2/bundler/gems/fontcustom-5ad0974ca188/lib/fontcustom/scripts/generate.py", line 129, in <module>
                  subprocess.run('python ' + scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -o ' + fontfile + '.eot', shell=True, check=True)
                File "/usr/local/Cellar/python@3.11/3.11.1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 571, in run
                  raise CalledProcessError(retcode, process.args,
              subprocess.CalledProcessError: Command 'python /Users/dburgess/.gem/ruby/2.7.2/bundler/gems/fontcustom-5ad0974ca188/lib/fontcustom/scripts/eotlitetool.py stylesheets/icons.ttf -o stylesheets/icons.eot' returned non-zero exit status 127.
       error  `fontforge` compilation failed.
```

The error is a bit obscured, however does state python not found right above the traceback