### PR TITLE
Fix-1038: Update for ruby 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.0 (11/18/2024)
+* Update to support [Ruby 3.2 removals](https://rubyreferences.github.io/rubychanges/3.2.html#removals)
+
 ## 2.2.0 (02/8/2023)
 * Add check for call status to eotlite.py
 * Update python default call to eotlitetool.py to python3

--- a/lib/fontcustom/manifest.rb
+++ b/lib/fontcustom/manifest.rb
@@ -7,7 +7,7 @@ module Fontcustom
     def initialize(manifest, cli_options = {})
       @manifest = manifest
       @cli_options = symbolize_hash cli_options
-      if File.exists? @manifest
+      if File.exist? @manifest
         reload
         if ! @cli_options.empty? && get(:options) != @cli_options
           set :options, @cli_options

--- a/lib/fontcustom/options.rb
+++ b/lib/fontcustom/options.rb
@@ -39,17 +39,17 @@ module Fontcustom
     def set_config_path
       @cli_options[:config] = if @cli_options[:config]
         path = @cli_options[:config]
-        if File.exists?(path) && ! File.directory?(path)
+        if File.exist?(path) && ! File.directory?(path)
           path
-        elsif File.exists? File.join(path, "fontcustom.yml")
+        elsif File.exist? File.join(path, "fontcustom.yml")
           File.join path, "fontcustom.yml"
         else
           raise Fontcustom::Error, "No configuration file found at `#{path}`."
         end
       else
-        if File.exists? "fontcustom.yml"
+        if File.exist? "fontcustom.yml"
           "fontcustom.yml"
-        elsif File.exists? File.join("config", "fontcustom.yml")
+        elsif File.exist? File.join("config", "fontcustom.yml")
           File.join "config", "fontcustom.yml"
         else
           false
@@ -134,7 +134,7 @@ module Fontcustom
 
         @options[:output].each do |key, val|
           @options[:output][key] = val
-          if File.exists?(val) && ! File.directory?(val)
+          if File.exist?(val) && ! File.directory?(val)
             raise Fontcustom::Error,
               "Output `#{@options[:output][key]}` exists but isn't a directory. Check your options."
           end
@@ -145,7 +145,7 @@ module Fontcustom
       else
         if @options[:output].is_a? String
           output = @options[:output]
-          if File.exists?(output) && ! File.directory?(output)
+          if File.exist?(output) && ! File.directory?(output)
             raise Fontcustom::Error,
               "Output `#{output}` exists but isn't a directory. Check your options."
           end
@@ -170,7 +170,7 @@ module Fontcustom
         else
           path = File.expand_path File.join(@options[:input][:templates], template)
         end
-        unless File.exists? path
+        unless File.exist? path
           raise Fontcustom::Error,
             "Custom template `#{template}` wasn't found in `#{@options[:input][:templates]}/`. Check your options."
         end
@@ -178,7 +178,7 @@ module Fontcustom
     end
 
     def check_input(dir)
-      if ! File.exists? dir
+      if ! File.exist? dir
         raise Fontcustom::Error,
           "Input `#{dir}` doesn't exist. Check your options."
       elsif ! File.directory? dir

--- a/spec/fontcustom/cli_spec.rb
+++ b/spec/fontcustom/cli_spec.rb
@@ -11,7 +11,7 @@ describe Fontcustom::CLI do
 
         expect(Dir.glob(File.join(testdir, "fontcustom", "fontcustom_*\.{ttf,svg,woff,eot}")).length).to eq(4)
         expect(File.read(manifest)).to match(/"fonts":.+fontcustom\/fontcustom_.+\.ttf"/m)
-        expect(File.exists?(preview)).to be_truthy
+        expect(File.exist?(preview)).to be_truthy
       end
     end
 

--- a/spec/fontcustom/watcher_spec.rb
+++ b/spec/fontcustom/watcher_spec.rb
@@ -64,7 +64,7 @@ describe Fontcustom::Watcher do
         ensure
           w.send :stop
           new = fixture("shared/vectors/test.svg")
-          FileUtils.rm(new) if File.exists?(new)
+          FileUtils.rm(new) if File.exist?(new)
         end
       end
     end
@@ -113,7 +113,7 @@ describe Fontcustom::Watcher do
         ensure
           w.send :stop
           new = fixture("shared/vectors/non-vector-file")
-          FileUtils.rm(new) if File.exists?(new)
+          FileUtils.rm(new) if File.exist?(new)
         end
       end
     end


### PR DESCRIPTION
Ruby 3.2 finally removed the deprecated `File#exists?` method. `File#exist?` has existed since Ruby 2.x